### PR TITLE
chore(ci): declare explicit permissions for read-default rollout

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -3,6 +3,9 @@ name: Update generated artifacts
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
## What

Declare explicit `permissions: contents: write` on `.github/workflows/generate.yaml` so the workflow continues to push regenerated artifacts after the org-wide flip to read-default `GITHUB_TOKEN`.

## Why

OSPO hardening — Finding 1: `restrict_default_workflow_permissions = true` will be enabled fleet-wide on the SAP CS-DevOps OSPO repo set. This workflow performs `git push` using the default `GITHUB_TOKEN` from `actions/checkout`; without an explicit permissions block it will start failing under the read-only default.

## Risk

Low. We narrow the token's effective scope (currently implicit write-everything; becomes read all + write contents) instead of broadening it. No behavior change on the happy path — the workflow continues to push as before.

## Test plan

- [ ] Trigger via `workflow_dispatch` and confirm the regenerate-and-push step still succeeds.